### PR TITLE
Add more tests for better coverage

### DIFF
--- a/tests/TestCase/Utility/ConfigTest.php
+++ b/tests/TestCase/Utility/ConfigTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace QrCode\Test\TestCase\Utility;
+
+use Cake\TestSuite\TestCase;
+use QrCode\Utility\Config;
+
+/**
+ * @uses \QrCode\Utility\Config
+ */
+class ConfigTest extends TestCase {
+
+	/**
+	 * Test TYPE_DEFAULT constant
+	 *
+	 * @return void
+	 */
+	public function testTypeDefault(): void {
+		$this->assertSame('', Config::TYPE_DEFAULT);
+	}
+
+	/**
+	 * Test TYPE_SVG constant
+	 *
+	 * @return void
+	 */
+	public function testTypeSvg(): void {
+		$this->assertSame('svg', Config::TYPE_SVG);
+	}
+
+	/**
+	 * Test TYPE_PNG constant
+	 *
+	 * @return void
+	 */
+	public function testTypePng(): void {
+		$this->assertSame('png', Config::TYPE_PNG);
+	}
+
+}

--- a/tests/TestCase/View/Helper/QrCodeHelperTest.php
+++ b/tests/TestCase/View/Helper/QrCodeHelperTest.php
@@ -6,6 +6,7 @@ namespace QrCode\Test\TestCase\View\Helper;
 use Cake\TestSuite\TestCase;
 use Cake\View\View;
 use Imagick;
+use QrCode\Utility\FormatterInterface;
 use QrCode\View\Helper\QrCodeHelper;
 
 class QrCodeHelperTest extends TestCase {
@@ -73,6 +74,131 @@ class QrCodeHelperTest extends TestCase {
 		$this->assertInstanceOf(Imagick::class, $image);
 
 		$this->assertNotEmpty($image->getImageBlob());
+	}
+
+	/**
+	 * @uses \QrCode\View\Helper\QrCodeHelper::png()
+	 *
+	 * @return void
+	 */
+	public function testPng(): void {
+		$content = 'Foo Bar';
+		$image = $this->QrCode->png($content);
+		$this->assertNotEmpty($image);
+		$expected = '<img src="/qr-code/qr-code/image.png?content=Foo+Bar" alt="QR Code">';
+		$this->assertSame($expected, $image);
+	}
+
+	/**
+	 * @uses \QrCode\View\Helper\QrCodeHelper::raw()
+	 *
+	 * @return void
+	 */
+	public function testRaw(): void {
+		$content = 'Test Content';
+		$raw = $this->QrCode->raw($content);
+		$this->assertNotEmpty($raw);
+		$this->assertStringContainsString('<svg', $raw);
+	}
+
+	/**
+	 * @uses \QrCode\View\Helper\QrCodeHelper::formatter()
+	 *
+	 * @return void
+	 */
+	public function testFormatter(): void {
+		$formatter = $this->QrCode->formatter();
+		$this->assertInstanceOf(FormatterInterface::class, $formatter);
+	}
+
+	/**
+	 * @uses \QrCode\View\Helper\QrCodeHelper::image()
+	 *
+	 * @return void
+	 */
+	public function testImageWithOptions(): void {
+		$content = 'Test';
+		$image = $this->QrCode->image($content, ['level' => 'M']);
+		$this->assertNotEmpty($image);
+		$this->assertStringStartsWith('<img src="data:image/svg+xml;base64,', $image);
+	}
+
+	/**
+	 * Test image with ECC level Q
+	 *
+	 * @uses \QrCode\View\Helper\QrCodeHelper::image()
+	 *
+	 * @return void
+	 */
+	public function testImageWithLevelQ(): void {
+		$content = 'Test';
+		$image = $this->QrCode->image($content, ['level' => 'Q']);
+		$this->assertNotEmpty($image);
+	}
+
+	/**
+	 * Test image with ECC level H
+	 *
+	 * @uses \QrCode\View\Helper\QrCodeHelper::image()
+	 *
+	 * @return void
+	 */
+	public function testImageWithLevelH(): void {
+		$content = 'Test';
+		$image = $this->QrCode->image($content, ['level' => 'H']);
+		$this->assertNotEmpty($image);
+	}
+
+	/**
+	 * Test image with margin
+	 *
+	 * @uses \QrCode\View\Helper\QrCodeHelper::image()
+	 *
+	 * @return void
+	 */
+	public function testImageWithMargin(): void {
+		$content = 'Test';
+		$image = $this->QrCode->image($content, ['margin' => 10]);
+		$this->assertNotEmpty($image);
+	}
+
+	/**
+	 * Test image with transparent background
+	 *
+	 * @uses \QrCode\View\Helper\QrCodeHelper::image()
+	 *
+	 * @return void
+	 */
+	public function testImageWithTransparent(): void {
+		$content = 'Test';
+		$image = $this->QrCode->image($content, ['transparent' => true]);
+		$this->assertNotEmpty($image);
+	}
+
+	/**
+	 * Test svg with query options
+	 *
+	 * @uses \QrCode\View\Helper\QrCodeHelper::svg()
+	 *
+	 * @return void
+	 */
+	public function testSvgWithOptions(): void {
+		$content = 'Test';
+		$image = $this->QrCode->svg($content, ['level' => 'H']);
+		$this->assertStringContainsString('level=H', $image);
+	}
+
+	/**
+	 * Test png with query options
+	 *
+	 * @uses \QrCode\View\Helper\QrCodeHelper::png()
+	 *
+	 * @return void
+	 */
+	public function testPngWithOptions(): void {
+		$content = 'Test';
+		$image = $this->QrCode->png($content, ['scale' => 5]);
+		$this->assertStringContainsString('scale=5', $image);
 	}
 
 }

--- a/tests/TestCase/View/QrCodeViewTest.php
+++ b/tests/TestCase/View/QrCodeViewTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace QrCode\Test\TestCase\View;
+
+use Cake\Http\Response;
+use Cake\Http\ServerRequest;
+use Cake\TestSuite\TestCase;
+use QrCode\View\QrCodeView;
+
+/**
+ * @uses \QrCode\View\QrCodeView
+ */
+class QrCodeViewTest extends TestCase {
+
+	/**
+	 * Test contentType returns correct MIME type
+	 *
+	 * @return void
+	 */
+	public function testContentType(): void {
+		$this->assertSame('image/svg+xml', QrCodeView::contentType());
+	}
+
+	/**
+	 * Test constructor disables auto layout
+	 *
+	 * @return void
+	 */
+	public function testConstructorDisablesLayout(): void {
+		$request = new ServerRequest(['params' => ['_ext' => 'svg']]);
+		$response = new Response();
+		$view = new QrCodeView($request, $response);
+
+		$this->assertSame('', $view->getLayout());
+	}
+
+	/**
+	 * Test initialize sets content type for SVG
+	 *
+	 * @return void
+	 */
+	public function testInitializeSetsSvgContentType(): void {
+		$request = new ServerRequest(['params' => ['_ext' => 'svg']]);
+		$response = new Response();
+		$view = new QrCodeView($request, $response);
+
+		$response = $view->getResponse();
+		$this->assertStringContainsString('image/svg+xml', $response->getHeaderLine('Content-Type'));
+	}
+
+	/**
+	 * Test initialize sets content type for PNG
+	 *
+	 * @return void
+	 */
+	public function testInitializeSetsPngContentType(): void {
+		$request = new ServerRequest(['params' => ['_ext' => 'png']]);
+		$response = new Response();
+		$view = new QrCodeView($request, $response);
+
+		$response = $view->getResponse();
+		$this->assertStringContainsString('image/png', $response->getHeaderLine('Content-Type'));
+	}
+
+	/**
+	 * Test initialize with default extension (svg)
+	 *
+	 * @return void
+	 */
+	public function testInitializeWithDefaultExtension(): void {
+		$request = new ServerRequest();
+		$response = new Response();
+		$view = new QrCodeView($request, $response);
+
+		$response = $view->getResponse();
+		$this->assertStringContainsString('image/svg+xml', $response->getHeaderLine('Content-Type'));
+	}
+
+	/**
+	 * Test constructor without parameters
+	 *
+	 * @return void
+	 */
+	public function testConstructorWithoutParams(): void {
+		$view = new QrCodeView();
+		$this->assertSame('', $view->getLayout());
+	}
+
+	/**
+	 * Test default config
+	 *
+	 * @return void
+	 */
+	public function testDefaultConfig(): void {
+		$view = new QrCodeView();
+		$this->assertSame('svg', $view->getConfig('ext'));
+	}
+
+}


### PR DESCRIPTION
## Summary

- Add QrCodeHelperTest: tests for png(), raw(), formatter(), normalizeOptions() with all ECC levels (L, M, Q, H), margin, and transparent options
- Add ConfigTest: tests for type constants (TYPE_DEFAULT, TYPE_SVG, TYPE_PNG)
- Add QrCodeViewTest: tests for contentType(), constructor behavior, initialize with different extensions (svg, png)

This improves test coverage by testing previously uncovered code paths.