### PR TITLE
Support chillerlan/php-qrcode v6 (with v5 compat shim)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,16 @@ jobs:
         php-version: ['8.2', '8.5']
         db-type: ['sqlite']
         prefer-lowest: ['']
+        chillerlan-version: ['']
         include:
           - php-version: '8.2'
             db-type: 'sqlite'
             prefer-lowest: 'prefer-lowest'
+            chillerlan-version: ''
+          - php-version: '8.5'
+            db-type: 'sqlite'
+            prefer-lowest: ''
+            chillerlan-version: '^6.0'
 
     services:
       postgres:
@@ -54,6 +60,10 @@ jobs:
           then
             composer update --prefer-lowest --prefer-stable
             composer require --dev dereuromark/composer-prefer-lowest:dev-master
+          elif [ -n "${{ matrix.chillerlan-version }}" ]
+          then
+            composer require --no-update "chillerlan/php-qrcode:${{ matrix.chillerlan-version }}"
+            composer install --no-progress --prefer-dist --optimize-autoloader
           else
             composer install --no-progress --prefer-dist --optimize-autoloader
           fi

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
 	"require": {
 		"php": ">=8.2",
 		"cakephp/cakephp": "^5.1.1",
-		"chillerlan/php-qrcode": "^5.0"
+		"chillerlan/php-qrcode": "^5.0 || ^6.0"
 	},
 	"require-dev": {
 		"fig-r/psr2r-sniffer": "dev-master",

--- a/src/Controller/Admin/QrCodeController.php
+++ b/src/Controller/Admin/QrCodeController.php
@@ -6,8 +6,8 @@ namespace QrCode\Controller\Admin;
 use App\Controller\AppController;
 use Cake\Core\Configure;
 use Cake\Http\Exception\BadRequestException;
-use chillerlan\QRCode\Output\QROutputInterface;
 use InvalidArgumentException;
+use QrCode\Lib\OutputType;
 use QrCode\Utility\Formatter;
 use QrCode\Utility\FormatterInterface;
 
@@ -40,7 +40,7 @@ class QrCodeController extends AppController {
 		$options = [];
 
 		if ($this->request->getParam('_ext') === 'png') {
-			$options['outputType'] = QROutputInterface::GDIMAGE_PNG;
+			$options = OutputType::apply($options, OutputType::PNG);
 		}
 
 		$this->set(compact('result', 'options'));

--- a/src/Controller/QrCodeController.php
+++ b/src/Controller/QrCodeController.php
@@ -5,8 +5,8 @@ namespace QrCode\Controller;
 use App\Controller\AppController;
 use Cake\Core\Configure;
 use Cake\Http\Exception\BadRequestException;
-use chillerlan\QRCode\Output\QROutputInterface;
 use InvalidArgumentException;
+use QrCode\Lib\OutputType;
 use QrCode\Utility\Formatter;
 use QrCode\Utility\FormatterInterface;
 use QrCode\View\QrCodePngView;
@@ -35,7 +35,7 @@ class QrCodeController extends AppController {
 		$options = [];
 
 		if ($this->request->getParam('_ext') === 'png') {
-			$options['outputType'] = QROutputInterface::GDIMAGE_PNG;
+			$options = OutputType::apply($options, OutputType::PNG);
 		}
 
 		$this->set(compact('result', 'options'));

--- a/src/Lib/OutputType.php
+++ b/src/Lib/OutputType.php
@@ -1,0 +1,78 @@
+<?php
+declare(strict_types=1);
+
+namespace QrCode\Lib;
+
+use chillerlan\QRCode\Output\QRGdImagePNG;
+use chillerlan\QRCode\Output\QRImagick;
+use chillerlan\QRCode\Output\QRMarkupSVG;
+use chillerlan\QRCode\Output\QROutputInterface;
+use InvalidArgumentException;
+
+/**
+ * Compatibility shim for chillerlan/php-qrcode v5 and v6.
+ *
+ * v5 selected output via the `outputType` string option (e.g. 'png', 'imagick').
+ * v6 removed `outputType` entirely and selects output via the `outputInterface`
+ * class-name option (e.g. QRGdImagePNG::class).
+ *
+ * Why both: the v5 default for `outputInterface` is null and is only honored
+ * when `outputType === QROutputInterface::CUSTOM`; v6 honors `outputInterface`
+ * directly. Setting both keeps the same call site working across majors.
+ */
+class OutputType {
+
+	/**
+	 * @var string
+	 */
+	public const PNG = 'png';
+
+	/**
+	 * @var string
+	 */
+	public const SVG = 'svg';
+
+	/**
+	 * @var string
+	 */
+	public const IMAGICK = 'imagick';
+
+	/**
+	 * @var array<string, class-string>
+	 */
+	protected const CLASS_MAP = [
+		self::PNG => QRGdImagePNG::class,
+		self::SVG => QRMarkupSVG::class,
+		self::IMAGICK => QRImagick::class,
+	];
+
+	/**
+	 * @return bool True when chillerlan/php-qrcode v6+ is installed.
+	 */
+	public static function isV6(): bool {
+		return !defined(QROutputInterface::class . '::GDIMAGE_PNG');
+	}
+
+	/**
+	 * @param array<string, mixed> $options
+	 * @param string $type One of self::PNG, self::SVG, self::IMAGICK.
+	 *
+	 * @throws \InvalidArgumentException When $type is not a known output type.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public static function apply(array $options, string $type): array {
+		if (!isset(static::CLASS_MAP[$type])) {
+			throw new InvalidArgumentException(sprintf('Unknown output type: %s', $type));
+		}
+
+		$options['outputInterface'] = static::CLASS_MAP[$type];
+
+		if (!static::isV6()) {
+			$options['outputType'] = constant(QROutputInterface::class . '::CUSTOM');
+		}
+
+		return $options;
+	}
+
+}

--- a/src/View/Helper/QrCodeHelper.php
+++ b/src/View/Helper/QrCodeHelper.php
@@ -5,10 +5,10 @@ namespace QrCode\View\Helper;
 use Cake\View\Helper;
 use chillerlan\QRCode\Common\EccLevel;
 use chillerlan\QRCode\Common\Version;
-use chillerlan\QRCode\Output\QROutputInterface;
 use chillerlan\QRCode\QRCode;
 use chillerlan\QRCode\QROptions;
 use InvalidArgumentException;
+use QrCode\Lib\OutputType;
 use QrCode\Utility\Config;
 use QrCode\Utility\Formatter;
 use QrCode\Utility\FormatterInterface;
@@ -148,7 +148,7 @@ class QrCodeHelper extends Helper {
 		$options = $this->normalizeOptions($options);
 
 		$options['outputBase64'] = false;
-		$options['outputType'] = QROutputInterface::IMAGICK;
+		$options = OutputType::apply($options, OutputType::IMAGICK);
 		$options['returnResource'] = true;
 
 		return (new QRCode(new QROptions($options)))->render($content);

--- a/tests/TestCase/Lib/OutputTypeTest.php
+++ b/tests/TestCase/Lib/OutputTypeTest.php
@@ -1,0 +1,150 @@
+<?php
+declare(strict_types=1);
+
+namespace QrCode\Test\TestCase\Lib;
+
+use Cake\TestSuite\TestCase;
+use chillerlan\QRCode\Output\QRGdImagePNG;
+use chillerlan\QRCode\Output\QRImagick;
+use chillerlan\QRCode\Output\QRMarkupSVG;
+use chillerlan\QRCode\Output\QROutputInterface;
+use chillerlan\QRCode\QRCode;
+use chillerlan\QRCode\QROptions;
+use Imagick;
+use InvalidArgumentException;
+use QrCode\Lib\OutputType;
+
+/**
+ * @uses \QrCode\Lib\OutputType
+ */
+class OutputTypeTest extends TestCase {
+
+	/**
+	 * @return void
+	 */
+	public function testApplyPngSetsOutputInterface(): void {
+		$options = OutputType::apply([], OutputType::PNG);
+
+		$this->assertArrayHasKey('outputInterface', $options);
+		$this->assertSame(QRGdImagePNG::class, $options['outputInterface']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testApplyImagickSetsOutputInterface(): void {
+		$options = OutputType::apply([], OutputType::IMAGICK);
+
+		$this->assertArrayHasKey('outputInterface', $options);
+		$this->assertSame(QRImagick::class, $options['outputInterface']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testApplySvgSetsOutputInterface(): void {
+		$options = OutputType::apply([], OutputType::SVG);
+
+		$this->assertArrayHasKey('outputInterface', $options);
+		$this->assertSame(QRMarkupSVG::class, $options['outputInterface']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testApplyPreservesOtherOptions(): void {
+		$options = OutputType::apply(['scale' => 5, 'margin' => 2], OutputType::PNG);
+
+		$this->assertSame(5, $options['scale']);
+		$this->assertSame(2, $options['margin']);
+	}
+
+	/**
+	 * v5 needs `outputType => CUSTOM` to actually use the `outputInterface` override.
+	 * v6 removed `outputType` entirely.
+	 *
+	 * @return void
+	 */
+	public function testApplySetsOutputTypeCustomOnV5(): void {
+		if (OutputType::isV6()) {
+			$this->markTestSkipped('Only relevant on chillerlan/php-qrcode v5.');
+		}
+
+		$options = OutputType::apply([], OutputType::PNG);
+
+		$this->assertArrayHasKey('outputType', $options);
+		$this->assertSame('custom', $options['outputType']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testApplyOmitsOutputTypeOnV6(): void {
+		if (!OutputType::isV6()) {
+			$this->markTestSkipped('Only relevant on chillerlan/php-qrcode v6.');
+		}
+
+		$options = OutputType::apply([], OutputType::PNG);
+
+		$this->assertArrayNotHasKey('outputType', $options);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testApplyThrowsForUnknownType(): void {
+		$this->expectException(InvalidArgumentException::class);
+
+		OutputType::apply([], 'bogus');
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testIsV6DetectsByConstantPresence(): void {
+		$expected = !defined(QROutputInterface::class . '::GDIMAGE_PNG');
+
+		$this->assertSame($expected, OutputType::isV6());
+	}
+
+	/**
+	 * End-to-end: shim-prepared options actually produce a PNG when passed to QRCode.
+	 *
+	 * @return void
+	 */
+	public function testEndToEndProducesPng(): void {
+		$options = OutputType::apply(['outputBase64' => false], OutputType::PNG);
+		$result = (new QRCode(new QROptions($options)))->render('Foo Bar');
+
+		$this->assertIsString($result);
+		$this->assertStringStartsWith("\x89PNG\r\n\x1a\n", $result);
+	}
+
+	/**
+	 * End-to-end: shim-prepared options produce SVG markup.
+	 *
+	 * @return void
+	 */
+	public function testEndToEndProducesSvg(): void {
+		$options = OutputType::apply(['outputBase64' => false], OutputType::SVG);
+		$result = (new QRCode(new QROptions($options)))->render('Foo Bar');
+
+		$this->assertIsString($result);
+		$this->assertStringContainsString('<svg', $result);
+	}
+
+	/**
+	 * End-to-end: shim-prepared options produce an Imagick instance.
+	 *
+	 * @return void
+	 */
+	public function testEndToEndProducesImagickResource(): void {
+		$this->skipIf(!class_exists(Imagick::class), 'Imagick not available');
+
+		$options = OutputType::apply(['outputBase64' => false, 'returnResource' => true], OutputType::IMAGICK);
+		$result = (new QRCode(new QROptions($options)))->render('Foo Bar');
+
+		$this->assertInstanceOf(Imagick::class, $result);
+	}
+
+}


### PR DESCRIPTION
## Summary

- Adds support for `chillerlan/php-qrcode ^6.0` while keeping `^5.0` working
- Introduces a small `QrCode\Lib\OutputType` shim that resolves the v5↔v6 API divergence
- CI matrix gains a job pinned to chillerlan `^6.0` so both majors are covered on every push

## Why a shim

Chillerlan v6 is a breaking release for the bits this plugin used:

- `QROptions::$outputType` and the `QROutputInterface::*` constants are **gone** in v6
- Output is now selected via `QROptions::$outputInterface = QRGdImagePNG::class` (or similar)
- v5 also has `$outputInterface`, but only honors it when `$outputType === QROutputInterface::CUSTOM`

The shim sets `outputInterface` (works in both majors) and additionally sets `outputType = CUSTOM` only when running under v5, so the same call sites work regardless of which major is installed.

## Changes

- `src/Lib/OutputType.php` — new shim with `apply()` and `isV6()` helpers
- `src/Controller/QrCodeController.php` and `src/Controller/Admin/QrCodeController.php` — use shim for PNG output
- `src/View/Helper/QrCodeHelper.php` — use shim for Imagick resource output
- `composer.json` — `chillerlan/php-qrcode: ^5.0 || ^6.0`
- `.github/workflows/ci.yml` — extra matrix job that forces `^6.0`
- `tests/TestCase/Lib/OutputTypeTest.php` — 11 tests covering shim behavior + version-specific branches + end-to-end PNG/SVG/Imagick rendering

Verified locally on chillerlan 5.0.0, 5.0.5, and 6.0.1: phpunit, phpstan, and phpcs all clean.