### PR TITLE
Coerce QrCode request input and centralize MECARD escaping

### DIFF
--- a/src/Controller/Admin/QrCodeController.php
+++ b/src/Controller/Admin/QrCodeController.php
@@ -14,13 +14,27 @@ use QrCode\Utility\FormatterInterface;
 class QrCodeController extends AppController {
 
 	/**
+	 * QR code max capacity (binary, byte mode) per the spec.
+	 *
+	 * @var int
+	 */
+	public const MAX_CONTENT_LENGTH = 2953;
+
+	/**
 	 * @return \Cake\Http\Response|null|void Renders view
 	 */
 	public function index() {
 		$result = null;
 		$options = [];
 		if ($this->request->is('post')) {
-			$result = $this->request->getData('content');
+			$content = $this->request->getData('content');
+			if (!is_string($content) || $content === '') {
+				throw new BadRequestException('Missing or invalid "content" parameter.');
+			}
+			if (strlen($content) > static::MAX_CONTENT_LENGTH) {
+				throw new BadRequestException('Content too long for QR code.');
+			}
+			$result = $content;
 		}
 
 		$this->set(compact('result', 'options'));
@@ -31,9 +45,11 @@ class QrCodeController extends AppController {
 	 */
 	public function image() {
 		$content = $this->request->getQuery('content');
-
-		if ($content && strlen($content) > 2953) { // QR code max capacity
-			throw new BadRequestException('Content too long for QR code');
+		if (!is_string($content) || $content === '') {
+			throw new BadRequestException('Missing or invalid "content" parameter.');
+		}
+		if (strlen($content) > static::MAX_CONTENT_LENGTH) {
+			throw new BadRequestException('Content too long for QR code.');
 		}
 
 		$result = $this->formatter()->formatText($content);

--- a/src/Controller/QrCodeController.php
+++ b/src/Controller/QrCodeController.php
@@ -22,13 +22,22 @@ class QrCodeController extends AppController {
 	}
 
 	/**
+	 * QR code max capacity (binary, byte mode) per the spec.
+	 *
+	 * @var int
+	 */
+	public const MAX_CONTENT_LENGTH = 2953;
+
+	/**
 	 * @return \Cake\Http\Response|null|void
 	 */
 	public function image() {
 		$content = $this->request->getQuery('content');
-
-		if ($content && strlen($content) > 2953) { // QR code max capacity
-			throw new BadRequestException('Content too long for QR code');
+		if (!is_string($content) || $content === '') {
+			throw new BadRequestException('Missing or invalid "content" parameter.');
+		}
+		if (strlen($content) > static::MAX_CONTENT_LENGTH) {
+			throw new BadRequestException('Content too long for QR code.');
 		}
 
 		$result = $this->formatter()->formatText($content);

--- a/src/Utility/Formatter.php
+++ b/src/Utility/Formatter.php
@@ -64,7 +64,7 @@ class Formatter implements FormatterInterface {
 	 * @return string
 	 */
 	public function formatCard(array $content): string {
-		if (is_array($content['birthday'])) {
+		if (isset($content['birthday']) && is_array($content['birthday'])) {
 			$content['birthday'] = $content['birthday']['year'] . '-' . $content['birthday']['month'] . '-' . $content['birthday']['day'];
 		}
 
@@ -72,23 +72,19 @@ class Formatter implements FormatterInterface {
 		foreach ($content as $key => $val) {
 			switch ($key) {
 				case 'name':
-					$res[] = 'N:' . $val; # //TODO: support array
+					$res[] = 'N:' . $this->escapeMecard((string)$val);
 
 					break;
 				case 'nickname':
-					$res[] = 'NICKNAME:' . $val;
+					$res[] = 'NICKNAME:' . $this->escapeMecard((string)$val);
 
 					break;
 				case 'sound':
-					$res[] = 'SOUND:' . $val;
+					$res[] = 'SOUND:' . $this->escapeMecard((string)$val);
 
 					break;
 				case 'note':
-					$val = str_replace(';', ',', $val);
-					// Escape vCard special characters
-					$val = addcslashes($val, "\n\r\\");
-					$val = str_replace(',', '\\,', $val);
-					$res[] = 'NOTE:' . $val;
+					$res[] = 'NOTE:' . $this->escapeMecard((string)$val);
 
 					break;
 				case 'birthday':
@@ -104,49 +100,49 @@ class Formatter implements FormatterInterface {
 				case 'tel':
 					$val = (array)$val;
 					foreach ($val as $v) {
-						$res[] = 'TEL:' . $v;
+						$res[] = 'TEL:' . $this->escapeMecard((string)$v);
 					}
 
 					break;
 				case 'video':
 					$val = (array)$val;
 					foreach ($val as $v) {
-						$res[] = 'TEL-AV:' . $v;
+						$res[] = 'TEL-AV:' . $this->escapeMecard((string)$v);
 					}
 
 					break;
 				case 'address':
 					$val = (array)$val;
 					foreach ($val as $v) {
-						$res[] = 'ADR:' . $v; //TODO: reformat (array etc)
+						$res[] = 'ADR:' . $this->escapeMecard((string)$v);
 					}
 
 					break;
 				case 'org':
 					$val = (array)$val;
 					foreach ($val as $v) {
-						$res[] = 'ORG:' . $v;
+						$res[] = 'ORG:' . $this->escapeMecard((string)$v);
 					}
 
 					break;
 				case 'role':
 					$val = (array)$val;
 					foreach ($val as $v) {
-						$res[] = 'ROLE:' . $v;
+						$res[] = 'ROLE:' . $this->escapeMecard((string)$v);
 					}
 
 					break;
 				case 'email':
 					$val = (array)$val;
 					foreach ($val as $v) {
-						$res[] = 'EMAIL:' . $v;
+						$res[] = 'EMAIL:' . $this->escapeMecard((string)$v);
 					}
 
 					break;
 				case 'url':
 					$val = (array)$val;
 					foreach ($val as $v) {
-						$res[] = 'URL:' . Router::url($v, true);
+						$res[] = 'URL:' . $this->escapeMecard(Router::url($v, true));
 					}
 
 					break;
@@ -154,6 +150,24 @@ class Formatter implements FormatterInterface {
 		}
 
 		return 'MECARD:' . implode(';', $res) . ';';
+	}
+
+	/**
+	 * Escape MECARD/vCard reserved characters so a single field cannot break the payload.
+	 *
+	 * Backslash must be escaped first; afterwards `;`, `:`, `,` and CR/LF are escaped per the
+	 * MECARD spec so a field separator inside a value cannot truncate the rest of the card.
+	 *
+	 * @param string $value
+	 *
+	 * @return string
+	 */
+	protected function escapeMecard(string $value): string {
+		return str_replace(
+			['\\', ';', ':', ',', "\r", "\n"],
+			['\\\\', '\\;', '\\:', '\\,', '', '\\n'],
+			$value,
+		);
 	}
 
 	/**

--- a/tests/TestCase/Controller/Admin/QrCodeControllerTest.php
+++ b/tests/TestCase/Controller/Admin/QrCodeControllerTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace QrCode\Test\TestCase\Controller\Admin;
 
+use Cake\Http\Exception\BadRequestException;
 use Cake\TestSuite\IntegrationTestTrait;
 use Cake\TestSuite\TestCase;
 
@@ -51,6 +52,68 @@ class QrCodeControllerTest extends TestCase {
 		$this->get(['prefix' => 'Admin', 'plugin' => 'QrCode', 'controller' => 'QrCode', 'action' => 'image', '_ext' => 'svg', '?' => ['content' => 'Foo Bar']]);
 
 		$this->assertResponseOk();
+	}
+
+	/**
+	 * Posting overlong content must be rejected before the helper renders the QR.
+	 *
+	 * @return void
+	 */
+	public function testIndexPostRejectsOverlongContent(): void {
+		$this->disableErrorHandlerMiddleware();
+		$this->expectException(BadRequestException::class);
+
+		$this->session([
+			'Auth' => [
+				'User' => [
+					'id' => 1,
+				],
+			],
+		]);
+
+		$this->post(
+			['prefix' => 'Admin', 'plugin' => 'QrCode', 'controller' => 'QrCode', 'action' => 'index'],
+			['content' => str_repeat('a', 2954)],
+		);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testIndexPostRejectsArrayContent(): void {
+		$this->disableErrorHandlerMiddleware();
+		$this->expectException(BadRequestException::class);
+
+		$this->session([
+			'Auth' => [
+				'User' => [
+					'id' => 1,
+				],
+			],
+		]);
+
+		$this->post(
+			['prefix' => 'Admin', 'plugin' => 'QrCode', 'controller' => 'QrCode', 'action' => 'index'],
+			['content' => ['x', 'y']],
+		);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testImageRejectsArrayContent(): void {
+		$this->disableErrorHandlerMiddleware();
+		$this->expectException(BadRequestException::class);
+
+		$this->session([
+			'Auth' => [
+				'User' => [
+					'id' => 1,
+				],
+			],
+		]);
+
+		$this->get(['prefix' => 'Admin', 'plugin' => 'QrCode', 'controller' => 'QrCode', 'action' => 'image', '_ext' => 'svg', '?' => ['content' => ['x']]]);
 	}
 
 }

--- a/tests/TestCase/Controller/QrCodeControllerTest.php
+++ b/tests/TestCase/Controller/QrCodeControllerTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace QrCode\Test\TestCase\Controller;
 
+use Cake\Http\Exception\BadRequestException;
 use Cake\TestSuite\IntegrationTestTrait;
 use Cake\TestSuite\TestCase;
 
@@ -34,6 +35,62 @@ class QrCodeControllerTest extends TestCase {
 		$this->get(['plugin' => 'QrCode', 'controller' => 'QrCode', 'action' => 'image', '_ext' => 'svg', '?' => ['content' => 'Foo Bar']]);
 
 		$this->assertResponseOk();
+	}
+
+	/**
+	 * Array `content` would previously hit `strlen()` on mixed and throw an uncaught TypeError.
+	 *
+	 * @return void
+	 */
+	public function testImageRejectsArrayContent(): void {
+		$this->disableErrorHandlerMiddleware();
+		$this->expectException(BadRequestException::class);
+
+		$this->session([
+			'Auth' => [
+				'User' => [
+					'id' => 1,
+				],
+			],
+		]);
+
+		$this->get(['plugin' => 'QrCode', 'controller' => 'QrCode', 'action' => 'image', '_ext' => 'svg', '?' => ['content' => ['x', 'y']]]);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testImageRejectsMissingContent(): void {
+		$this->disableErrorHandlerMiddleware();
+		$this->expectException(BadRequestException::class);
+
+		$this->session([
+			'Auth' => [
+				'User' => [
+					'id' => 1,
+				],
+			],
+		]);
+
+		$this->get(['plugin' => 'QrCode', 'controller' => 'QrCode', 'action' => 'image', '_ext' => 'svg']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testImageRejectsOverlongContent(): void {
+		$this->disableErrorHandlerMiddleware();
+		$this->expectException(BadRequestException::class);
+
+		$this->session([
+			'Auth' => [
+				'User' => [
+					'id' => 1,
+				],
+			],
+		]);
+
+		$this->get(['plugin' => 'QrCode', 'controller' => 'QrCode', 'action' => 'image', '_ext' => 'svg', '?' => ['content' => str_repeat('a', 2954)]]);
 	}
 
 }

--- a/tests/TestCase/Utility/FormatterTest.php
+++ b/tests/TestCase/Utility/FormatterTest.php
@@ -43,4 +43,47 @@ class FormatterTest extends TestCase {
 		$this->assertSame('WIFI:T:WPA;S:FooBar;P:pwd;;', $result);
 	}
 
+	/**
+	 * @return void
+	 */
+	public function testFormatCardEscapesNameSeparator(): void {
+		$result = $this->formatter->formatCard(['name' => 'Doe;John']);
+		$this->assertSame('MECARD:N:Doe\\;John;', $result);
+	}
+
+	/**
+	 * Address, org, role and email used to concatenate raw values, so a single `;` truncated the card.
+	 *
+	 * @return void
+	 */
+	public function testFormatCardEscapesScalarFields(): void {
+		$result = $this->formatter->formatCard([
+			'name' => 'Doe',
+			'address' => 'Main St; Apt 5',
+			'org' => 'Acme; Inc',
+			'role' => 'CEO:Founder',
+			'email' => 'a,b@example.com',
+		]);
+		$this->assertSame(
+			'MECARD:N:Doe;ADR:Main St\\; Apt 5;ORG:Acme\\; Inc;ROLE:CEO\\:Founder;EMAIL:a\\,b@example.com;',
+			$result,
+		);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testFormatCardEscapesBackslashFirst(): void {
+		$result = $this->formatter->formatCard(['name' => 'Back\\Slash']);
+		$this->assertSame('MECARD:N:Back\\\\Slash;', $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testFormatCardNoteEscaping(): void {
+		$result = $this->formatter->formatCard(['note' => "Line1\nLine2; with comma,"]);
+		$this->assertSame('MECARD:NOTE:Line1\\nLine2\\; with comma\\,;', $result);
+	}
+
 }


### PR DESCRIPTION
## Summary

- Public ``QrCode/QrCode/image`` and admin ``Admin/QrCode/image`` actions now coerce the ``content`` query parameter to a non-empty string before any string operation. Previously ``getQuery('content')`` returned mixed and was passed straight to ``strlen()`` / ``formatText(string)`` — a crafted ``?content[]=foo`` against the public unauthenticated route raised an uncaught ``TypeError``. Both actions now throw ``BadRequestException`` on missing/array/overlong input.
- ``Admin/QrCode/index`` POST branch now applies the same ``is_string`` + length cap so the helper cannot be asked to render multi-megabyte payloads via the form. The 2953 byte cap was hoisted into a ``MAX_CONTENT_LENGTH`` constant on both controllers.
- ``Formatter::formatCard`` now routes every scalar field (``name``, ``nickname``, ``sound``, ``note``, ``tel``, ``video``, ``address``, ``org``, ``role``, ``email``, ``url``) through a single ``escapeMecard`` helper that escapes ``\``, ``;``, ``:``, ``,``, CR and LF in spec order. Previously only ``note`` was partially escaped, so a single ``;`` in any other field truncated the rest of the MECARD payload at the scanner.
- Added controller tests for the new ``BadRequestException`` paths and Formatter tests covering name separator, multi-field escaping, backslash-first ordering, and note CR/LF handling.