### PR TITLE
Use plugin-specific i18n domain for translations

### DIFF
--- a/resources/locales/qrcode.pot
+++ b/resources/locales/qrcode.pot
@@ -1,0 +1,25 @@
+# LANGUAGE translation of CakePHP Application
+# Copyright YEAR NAME <EMAIL@ADDRESS>
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"POT-Creation-Date: 2026-05-04 04:11+0200\n"
+"PO-Revision-Date: YYYY-mm-DD HH:MM+ZZZZ\n"
+"Last-Translator: NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <EMAIL@ADDRESS>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+msgid "Actions"
+msgstr ""
+
+msgid "QR Codes"
+msgstr ""
+
+msgid "Go"
+msgstr ""
+

--- a/templates/Admin/QrCode/index.php
+++ b/templates/Admin/QrCode/index.php
@@ -7,14 +7,14 @@
 ?>
 <nav class="actions large-3 medium-4 columns col-sm-4 col-xs-12" id="actions-sidebar">
     <ul class="side-nav nav nav-pills flex-column">
-        <li class="nav-item heading"><?= __('Actions') ?></li>
+        <li class="nav-item heading"><?= __d('qrcode', 'Actions') ?></li>
         <li class="nav-item">
         </li>
     </ul>
 </nav>
 <div class="qr-code index content large-9 medium-8 columns col-sm-8 col-12">
 
-    <h2><?= __('QR Codes') ?></h2>
+    <h2><?= __d('qrcode', 'QR Codes') ?></h2>
 
 	<p>By default, we render a simple SVG image that can be scaled up/down easily.</p>
 
@@ -36,7 +36,7 @@
 	echo $this->Form->control('content', ['autocomplete' => 'off', 'type' => 'textarea']);
 	?>
 	<div class="col-md-offset-2 col-md-6">
-		<?php echo $this->Form->button(__('Go'), ['class' => 'btn btn-success']);?>
+		<?php echo $this->Form->button(__d('qrcode', 'Go'), ['class' => 'btn btn-success']);?>
 	</div>
 	<?php echo $this->Form->end(); ?>
 


### PR DESCRIPTION
## Summary

- Convert the 3 `__()` calls in `templates/Admin/QrCode/index.php` to `__d('qrcode', ...)` so plugin strings live in their own domain.
- Add `resources/locales/qrcode.pot` (3 unique msgids) generated via `bin/cake i18n extract`.

## Why

Plugin strings were landing in the host app's `default` domain. Anyone translating the host app would have ended up translating this plugin's UI under their own domain — and shipping a translated language pack with the plugin was effectively impossible.

## Verification (local)

- phpunit: 48 / 48 (1 pre-existing skipped, unrelated)
- phpstan: no errors
- phpcs: clean