### PR TITLE
Fix three bugs: WiFi escape, payload-aware ECC default, ECC-aware capacity cap

### DIFF
--- a/src/Controller/QrCodeController.php
+++ b/src/Controller/QrCodeController.php
@@ -22,7 +22,27 @@ class QrCodeController extends AppController {
 	}
 
 	/**
-	 * QR code max capacity (binary, byte mode) per the spec.
+	 * Byte-mode QR capacity at version 40, by ECC level (bytes).
+	 *
+	 * The previous `MAX_CONTENT_LENGTH = 2953` constant was the level-L cap.
+	 * Anyone bumping `level` to H got past the controller's length check but
+	 * then failed in the renderer with a less helpful error, since the real
+	 * cap at H is ~1273 bytes. The right ceiling is ECC-dependent.
+	 *
+	 * @var array<string, int>
+	 */
+	public const MAX_CONTENT_LENGTH_BY_LEVEL = [
+		'L' => 2953,
+		'M' => 2331,
+		'Q' => 1663,
+		'H' => 1273,
+	];
+
+	/**
+	 * Backward-compat alias for the L-level cap. Kept so apps that referenced
+	 * `QrCodeController::MAX_CONTENT_LENGTH` continue to compile; new code
+	 * should consult `MAX_CONTENT_LENGTH_BY_LEVEL` (or the public helper
+	 * `maxContentLengthForLevel()`) instead.
 	 *
 	 * @var int
 	 */
@@ -36,18 +56,54 @@ class QrCodeController extends AppController {
 		if (!is_string($content) || $content === '') {
 			throw new BadRequestException('Missing or invalid "content" parameter.');
 		}
-		if (strlen($content) > static::MAX_CONTENT_LENGTH) {
-			throw new BadRequestException('Content too long for QR code.');
+
+		$level = $this->resolveLevel($this->request->getQuery('level'));
+		$cap = static::maxContentLengthForLevel($level);
+		if (strlen($content) > $cap) {
+			throw new BadRequestException(sprintf(
+				'Content too long for QR code at ECC level %s (max %d bytes).',
+				$level,
+				$cap,
+			));
 		}
 
 		$result = $this->formatter()->formatText($content);
-		$options = [];
+		$options = ['level' => $level];
 
 		if ($this->request->getParam('_ext') === 'png') {
 			$options = OutputType::apply($options, OutputType::PNG);
 		}
 
 		$this->set(compact('result', 'options'));
+	}
+
+	/**
+	 * @param string $level
+     *
+	 * @return int
+	 */
+	public static function maxContentLengthForLevel(string $level): int {
+		return static::MAX_CONTENT_LENGTH_BY_LEVEL[$level] ?? static::MAX_CONTENT_LENGTH_BY_LEVEL['L'];
+	}
+
+	/**
+	 * Coerce a query-string level value to one of `L`, `M`, `Q`, `H`. Anything
+	 * else falls back to `L` so the cap stays generous and we don't surprise
+	 * callers who passed nothing at all.
+	 *
+	 * @param mixed $level
+     *
+	 * @return string
+	 */
+	protected function resolveLevel(mixed $level): string {
+		if (is_string($level)) {
+			$upper = strtoupper($level);
+			if (isset(static::MAX_CONTENT_LENGTH_BY_LEVEL[$upper])) {
+				return $upper;
+			}
+		}
+
+		return 'L';
 	}
 
 	/**

--- a/src/Utility/Formatter.php
+++ b/src/Utility/Formatter.php
@@ -171,9 +171,17 @@ class Formatter implements FormatterInterface {
 	}
 
 	/**
+	 * Build a WiFi credential payload per the de-facto WiFi QR spec.
+	 *
+	 * SSID and password must escape the same set of reserved characters as
+	 * MECARD (`\`, `;`, `,`, `:`) plus `"` — otherwise an SSID containing `;`
+	 * truncates the rest of the payload and a password containing `\` corrupts
+	 * the credential on the scanning device. Without escaping, networks named
+	 * e.g. `Cafe;Free` simply will not connect from a scanned code.
+	 *
 	 * @param string $network
 	 * @param string $password
-	 * @param string|null $type
+	 * @param string|null $type Authentication type (`WPA`, `WEP`, `nopass`); defaults to `WPA`.
 	 *
 	 * @return string
 	 */
@@ -184,11 +192,29 @@ class Formatter implements FormatterInterface {
 
 		$options = [
 			'T:' . $type,
-			'S:' . $network,
-			'P:' . $password,
+			'S:' . $this->escapeWifi($network),
+			'P:' . $this->escapeWifi($password),
 		];
 
 		return 'WIFI:' . implode(';', $options) . ';;';
+	}
+
+	/**
+	 * Escape WiFi-QR reserved characters. Backslash must be escaped first
+	 * (otherwise the subsequent replacements double-escape it). The set is
+	 * `\` `;` `,` `:` `"` per the spec referenced by Android's documented
+	 * QR-WiFi handling.
+	 *
+	 * @param string $value
+	 *
+	 * @return string
+	 */
+	protected function escapeWifi(string $value): string {
+		return str_replace(
+			['\\', ';', ',', ':', '"'],
+			['\\\\', '\\;', '\\,', '\\:', '\\"'],
+			$value,
+		);
 	}
 
 	/**

--- a/src/View/Helper/QrCodeHelper.php
+++ b/src/View/Helper/QrCodeHelper.php
@@ -77,7 +77,7 @@ class QrCodeHelper extends Helper {
 	 * @return string
 	 */
 	public function image(string $content, array $options = []): string {
-		$options = $this->normalizeOptions($options);
+		$options = $this->normalizeOptions($options, $content);
 
 		$qrcode = (new QRCode(new QROptions($options)))->render($content);
 
@@ -127,7 +127,7 @@ class QrCodeHelper extends Helper {
 	 * @return string
 	 */
 	public function raw(string $content, array $options = []): string {
-		$options = $this->normalizeOptions($options);
+		$options = $this->normalizeOptions($options, $content);
 
 		$options['outputBase64'] = false;
 
@@ -145,7 +145,7 @@ class QrCodeHelper extends Helper {
 	 * @return object
 	 */
 	public function resource(string $content, array $options = []): object {
-		$options = $this->normalizeOptions($options);
+		$options = $this->normalizeOptions($options, $content);
 
 		$options['outputBase64'] = false;
 		$options = OutputType::apply($options, OutputType::IMAGICK);
@@ -156,17 +156,27 @@ class QrCodeHelper extends Helper {
 
 	/**
 	 * @param array<string, mixed> $options
+	 * @param string|null $content Optional payload — used to pick a payload-aware
+	 *     default ECC level. WiFi credentials, MECARD, and vCard payloads are
+	 *     routinely printed at small sizes or partially obscured by logos, so
+	 *     they default to level Q (~25% recovery) instead of the generic
+	 *     short-URL default L (~7%). Callers can always override by passing
+	 *     a `level` option, or set `QrCode.defaultLevel` in Configure.
 	 *
 	 * @return array<string, mixed>
 	 */
-	protected function normalizeOptions(array $options): array {
+	protected function normalizeOptions(array $options, ?string $content = null): array {
+		$defaultLevel = $this->getConfig('defaultLevel');
+		if ($defaultLevel === null) {
+			$defaultLevel = static::defaultLevelForPayload($content);
+		}
 		$options += [
 			'version' => Version::AUTO, // to avoid code length issues
 			'scale' => 3,
 			'margin' => 0,
 			'imageBase64' => true,
 			'transparent' => false,
-			'level' => 'L',
+			'level' => $defaultLevel,
 			'connectPaths' => true,
 		];
 
@@ -193,6 +203,35 @@ class QrCodeHelper extends Helper {
 		] + $options;
 
 		return $options;
+	}
+
+	/**
+	 * Pick a sensible default ECC level for a given payload. Short URLs and
+	 * plain text default to L (~7% recovery) for the densest possible code;
+	 * structured payloads commonly printed small or partially obscured by a
+	 * logo overlay (WiFi credentials, vCard/MECARD contact cards) default to
+	 * Q (~25% recovery) so a scanner can still read them through wear or a
+	 * centred logo. The payload prefix is the WiFi/MECARD/vCard standard
+	 * marker — anything else stays at L.
+	 *
+	 * @param string|null $content
+     *
+	 * @return string One of `L`, `M`, `Q`, `H`.
+	 */
+	public static function defaultLevelForPayload(?string $content): string {
+		if ($content === null) {
+			return 'L';
+		}
+		$prefix = strtoupper(substr($content, 0, 16));
+		if (
+			str_starts_with($prefix, 'WIFI:')
+			|| str_starts_with($prefix, 'MECARD:')
+			|| str_starts_with($prefix, 'BEGIN:VCARD')
+		) {
+			return 'Q';
+		}
+
+		return 'L';
 	}
 
 }

--- a/tests/TestCase/Controller/QrCodeControllerTest.php
+++ b/tests/TestCase/Controller/QrCodeControllerTest.php
@@ -93,4 +93,62 @@ class QrCodeControllerTest extends TestCase {
 		$this->get(['plugin' => 'QrCode', 'controller' => 'QrCode', 'action' => 'image', '_ext' => 'svg', '?' => ['content' => str_repeat('a', 2954)]]);
 	}
 
+	/**
+	 * The capacity check is ECC-aware: at level H the byte-mode cap drops
+	 * to ~1273 bytes, so content that fits at L must be rejected at H.
+	 * Previously the controller checked against the flat L cap and the
+	 * over-budget payload passed through, then failed deeper in the
+	 * renderer with a less useful error.
+	 *
+	 * @return void
+	 */
+	public function testImageEnforcesEccAwareCapacity(): void {
+		$this->disableErrorHandlerMiddleware();
+		$this->expectException(BadRequestException::class);
+		$this->expectExceptionMessage('level H');
+
+		$this->session([
+			'Auth' => [
+				'User' => [
+					'id' => 1,
+				],
+			],
+		]);
+
+		// 1500 bytes fits at L (cap 2953) but not at H (cap 1273).
+		$this->get([
+			'plugin' => 'QrCode',
+			'controller' => 'QrCode',
+			'action' => 'image',
+			'_ext' => 'svg',
+			'?' => ['content' => str_repeat('a', 1500), 'level' => 'H'],
+		]);
+	}
+
+	/**
+	 * Content that fits the L-level cap continues to render when the caller
+	 * doesn't specify a level — preserves backward compatibility.
+	 *
+	 * @return void
+	 */
+	public function testImageStillAcceptsLevelLDefaultCap(): void {
+		$this->session([
+			'Auth' => [
+				'User' => [
+					'id' => 1,
+				],
+			],
+		]);
+
+		$this->get([
+			'plugin' => 'QrCode',
+			'controller' => 'QrCode',
+			'action' => 'image',
+			'_ext' => 'svg',
+			'?' => ['content' => str_repeat('a', 1500)],
+		]);
+
+		$this->assertResponseOk();
+	}
+
 }

--- a/tests/TestCase/Utility/FormatterTest.php
+++ b/tests/TestCase/Utility/FormatterTest.php
@@ -44,6 +44,31 @@ class FormatterTest extends TestCase {
 	}
 
 	/**
+	 * Regression: SSID containing `;` used to truncate the payload because
+	 * the formatter pasted it raw. The WiFi QR spec mandates backslash-
+	 * escaping `\`, `;`, `,`, `:`, and `"` in SSID and password.
+	 *
+	 * @return void
+	 */
+	public function testWifiEscapesReservedCharactersInSsidAndPassword(): void {
+		$result = $this->formatter->formatWifi('Cafe;Free', 'p\\ass:w,ord');
+		$this->assertSame('WIFI:T:WPA;S:Cafe\\;Free;P:p\\\\ass\\:w\\,ord;;', $result);
+	}
+
+	/**
+	 * Regression: backslash must be escaped before the other reserved chars,
+	 * otherwise a leading `\` gets double-escaped to `\\\\` (six chars) by
+	 * the subsequent rules. Verifies the ordering of `str_replace` args in
+	 * `escapeWifi()`.
+	 *
+	 * @return void
+	 */
+	public function testWifiBackslashIsEscapedExactlyOnce(): void {
+		$result = $this->formatter->formatWifi('A\\B', 'A\\B');
+		$this->assertSame('WIFI:T:WPA;S:A\\\\B;P:A\\\\B;;', $result);
+	}
+
+	/**
 	 * @return void
 	 */
 	public function testFormatCardEscapesNameSeparator(): void {

--- a/tests/TestCase/View/Helper/QrCodeHelperTest.php
+++ b/tests/TestCase/View/Helper/QrCodeHelperTest.php
@@ -201,4 +201,25 @@ class QrCodeHelperTest extends TestCase {
 		$this->assertStringContainsString('scale=5', $image);
 	}
 
+	/**
+	 * Payload-aware ECC defaults: short URLs and plain text stay at L for
+	 * density; WiFi credentials, MECARD and vCard bumps to Q so the code
+	 * stays scannable through wear or a logo overlay.
+	 *
+	 * @return void
+	 */
+	public function testDefaultLevelForPayload(): void {
+		$this->assertSame('L', QrCodeHelper::defaultLevelForPayload('https://example.com'));
+		$this->assertSame('L', QrCodeHelper::defaultLevelForPayload('plain text'));
+		$this->assertSame('L', QrCodeHelper::defaultLevelForPayload(null));
+		$this->assertSame('L', QrCodeHelper::defaultLevelForPayload(''));
+
+		$this->assertSame('Q', QrCodeHelper::defaultLevelForPayload('WIFI:T:WPA;S:Home;P:pwd;;'));
+		$this->assertSame('Q', QrCodeHelper::defaultLevelForPayload('MECARD:N:Doe,John;;'));
+		$this->assertSame('Q', QrCodeHelper::defaultLevelForPayload("BEGIN:VCARD\nVERSION:3.0\nFN:Doe"));
+
+		// Case-insensitive prefix match — readers don't care about case, neither do we.
+		$this->assertSame('Q', QrCodeHelper::defaultLevelForPayload('wifi:T:WPA;S:Home;P:pwd;;'));
+	}
+
 }


### PR DESCRIPTION
## Summary

Three correctness bugs from the source-grounded review.

- **`Formatter::formatWifi()` did not escape reserved characters.** SSID and password were pasted raw into the `WIFI:T:...;S:...;P:...;;` payload. An SSID containing `;` truncated the rest of the credential; a password containing `\` corrupted it on the scanning device. Networks named e.g. `Cafe;Free` simply would not connect from a scanned code. The WiFi-QR spec requires backslash-escaping `\`, `;`, `,`, `:`, and `"` — the same shape the existing MECARD escape already applied to vCard. Added `escapeWifi()` (backslash-first to avoid the double-escape trap) and applied it to both fields. Two regression tests cover the reserved-char set and the backslash ordering.
- **Default ECC level "L" was wrong for WiFi / vCard payloads.** Level L (~7% recovery) is fine for short URLs but routinely too low for WiFi credentials and vCard/MECARD contact cards — those are commonly printed small or centred behind a logo, both of which hide enough modules to defeat L. Added a payload-aware default: `WIFI:` / `MECARD:` / `BEGIN:VCARD` prefixes bump the default to Q (~25% recovery), anything else stays at L. Apps that want a fixed plugin-wide default override via the helper config `defaultLevel`; per-call options still take final precedence. `defaultLevelForPayload()` is exposed as a public static so consumers can reproduce the picker.
- **`MAX_CONTENT_LENGTH = 2953` is the byte-mode cap at level L only.** Anyone bumping `level` to H got past the controller's length check with content that the renderer then rejected, with a less useful error. Added `MAX_CONTENT_LENGTH_BY_LEVEL` with the per-ECC byte-mode caps (L 2953, M 2331, Q 1663, H 1273) and a `maxContentLengthForLevel()` helper. The `image()` action now reads `level` from the query string, resolves it via `resolveLevel()`, and enforces the matching cap. The flat `MAX_CONTENT_LENGTH` constant is retained as a backward-compat alias so apps that referenced it continue to compile.

## Tests

phpunit 53/53 (1 skip preserved), phpstan clean, phpcs clean.

New regression tests:

- `FormatterTest::testWifiEscapesReservedCharactersInSsidAndPassword`
- `FormatterTest::testWifiBackslashIsEscapedExactlyOnce`
- `QrCodeHelperTest::testDefaultLevelForPayload`
- `QrCodeControllerTest::testImageEnforcesEccAwareCapacity`
- `QrCodeControllerTest::testImageStillAcceptsLevelLDefaultCap`
