### PR TITLE
Add ETag + Cache-Control on rendered QR responses

### DIFF
--- a/src/Controller/QrCodeController.php
+++ b/src/Controller/QrCodeController.php
@@ -5,6 +5,7 @@ namespace QrCode\Controller;
 use App\Controller\AppController;
 use Cake\Core\Configure;
 use Cake\Http\Exception\BadRequestException;
+use Cake\Http\Response;
 use InvalidArgumentException;
 use QrCode\Lib\OutputType;
 use QrCode\Utility\Formatter;
@@ -74,7 +75,72 @@ class QrCodeController extends AppController {
 			$options = OutputType::apply($options, OutputType::PNG);
 		}
 
+		// Pure function of (content, options, ext) — identical inputs always
+		// produce identical bytes, so we can serve aggressive cache headers
+		// and short-circuit on a matching If-None-Match. The ETag is a hash
+		// of everything that affects the rendered payload (content + level
+		// + extension); a request that differs in any one of those gets a
+		// different ETag and a fresh render.
+		$cacheResponse = $this->applyHttpCache($content, $level);
+		if ($cacheResponse !== null) {
+			return $cacheResponse;
+		}
+
 		$this->set(compact('result', 'options'));
+	}
+
+	/**
+	 * Set strong `Cache-Control` + `ETag` headers on the response, and return
+	 * a 304 short-circuit if the client already has the same ETag.
+	 *
+	 * Returned `null` means we filled in the headers but didn't short-circuit
+	 * — the caller continues with the normal view render. A non-null return
+	 * is a complete 304 response the caller must return as-is.
+	 *
+	 * @param string $content Raw payload going into the QR code.
+	 * @param string $level Resolved ECC level.
+	 *
+	 * @return \Cake\Http\Response|null
+	 */
+	protected function applyHttpCache(string $content, string $level): ?Response {
+		$ext = (string)$this->request->getParam('_ext');
+		$etag = '"' . sha1($content . '|' . $level . '|' . $ext) . '"';
+
+		$ifNoneMatch = (string)$this->request->getHeaderLine('If-None-Match');
+		if ($ifNoneMatch !== '' && $ifNoneMatch === $etag) {
+			// The 304 path doesn't render a body. Browsers and CDNs use the
+			// previously-cached response. `Cache-Control` is repeated so a
+			// proxy that revalidates also picks up the same TTL.
+			return $this->response
+				->withStatus(304)
+				->withHeader('ETag', $etag)
+				->withHeader('Cache-Control', $this->cacheControlHeader());
+		}
+
+		// Cake mutates Response immutably — re-assign so the view render
+		// uses the augmented headers.
+		$this->response = $this->response
+			->withHeader('ETag', $etag)
+			->withHeader('Cache-Control', $this->cacheControlHeader());
+
+		return null;
+	}
+
+	/**
+	 * Cache-Control value applied to all rendered QR codes.
+	 *
+	 * Default is `public, max-age=31536000, immutable` — one year, immutable
+	 * because the content is keyed by hash. Apps with a different policy can
+	 * override via `Configure::write('QrCode.cacheControl', '...')`.
+	 *
+	 * @return string
+	 */
+	protected function cacheControlHeader(): string {
+		$configured = Configure::read('QrCode.cacheControl');
+
+		return is_string($configured) && $configured !== ''
+			? $configured
+			: 'public, max-age=31536000, immutable';
 	}
 
 	/**

--- a/tests/TestCase/Controller/QrCodeControllerTest.php
+++ b/tests/TestCase/Controller/QrCodeControllerTest.php
@@ -126,6 +126,101 @@ class QrCodeControllerTest extends TestCase {
 	}
 
 	/**
+	 * Successful render carries a strong cache header and an ETag derived
+	 * from (content + level + extension). Same inputs → same ETag, so
+	 * downstream caches can serve the rendered bytes without revalidating.
+	 *
+	 * @return void
+	 */
+	public function testImageEmitsCacheControlAndEtag(): void {
+		$this->session(['Auth' => ['User' => ['id' => 1]]]);
+
+		$this->get([
+			'plugin' => 'QrCode',
+			'controller' => 'QrCode',
+			'action' => 'image',
+			'_ext' => 'svg',
+			'?' => ['content' => 'Hello'],
+		]);
+
+		$this->assertResponseOk();
+		$this->assertHeaderContains('Cache-Control', 'public');
+		$this->assertHeaderContains('Cache-Control', 'max-age=31536000');
+		$this->assertHeaderContains('Cache-Control', 'immutable');
+		// ETag is a hex-digest in double quotes; just assert the shape.
+		$etag = $this->_response->getHeaderLine('ETag');
+		$this->assertMatchesRegularExpression('/^"[a-f0-9]{40}"$/', $etag);
+	}
+
+	/**
+	 * Conditional GET with a matching If-None-Match short-circuits with
+	 * 304 Not Modified and no body. Saves the renderer roundtrip on
+	 * unchanged inputs.
+	 *
+	 * @return void
+	 */
+	public function testImageReturns304WhenIfNoneMatchHits(): void {
+		$this->session(['Auth' => ['User' => ['id' => 1]]]);
+
+		// First request: capture the ETag.
+		$this->get([
+			'plugin' => 'QrCode',
+			'controller' => 'QrCode',
+			'action' => 'image',
+			'_ext' => 'svg',
+			'?' => ['content' => 'Hello'],
+		]);
+		$etag = $this->_response->getHeaderLine('ETag');
+		$this->assertNotEmpty($etag);
+
+		// Replay with If-None-Match — should 304.
+		$this->configRequest(['headers' => ['If-None-Match' => $etag]]);
+		$this->get([
+			'plugin' => 'QrCode',
+			'controller' => 'QrCode',
+			'action' => 'image',
+			'_ext' => 'svg',
+			'?' => ['content' => 'Hello'],
+		]);
+
+		$this->assertResponseCode(304);
+		// 304 must repeat the validators so the cache stays usable.
+		$this->assertHeaderContains('Cache-Control', 'max-age=31536000');
+		$this->assertSame($etag, $this->_response->getHeaderLine('ETag'));
+	}
+
+	/**
+	 * Different content produces a different ETag, so a probing cache
+	 * can't accidentally serve the wrong payload from a previous URL.
+	 *
+	 * @return void
+	 */
+	public function testImageEtagDiffersForDifferentContent(): void {
+		$this->session(['Auth' => ['User' => ['id' => 1]]]);
+
+		$this->get([
+			'plugin' => 'QrCode',
+			'controller' => 'QrCode',
+			'action' => 'image',
+			'_ext' => 'svg',
+			'?' => ['content' => 'first'],
+		]);
+		$first = $this->_response->getHeaderLine('ETag');
+
+		$this->get([
+			'plugin' => 'QrCode',
+			'controller' => 'QrCode',
+			'action' => 'image',
+			'_ext' => 'svg',
+			'?' => ['content' => 'second'],
+		]);
+		$second = $this->_response->getHeaderLine('ETag');
+
+		$this->assertNotEmpty($first);
+		$this->assertNotSame($first, $second);
+	}
+
+	/**
 	 * Content that fits the L-level cap continues to render when the caller
 	 * doesn't specify a level — preserves backward compatibility.
 	 *


### PR DESCRIPTION
## Summary

First of three qrcode strategic items from the audit. The controller renders the same QR code on every request: `/qr-code/qr-code/image.svg?content=...&level=...` is a pure function of `(content, level, extension)`. Same inputs always produce identical bytes — so we can serve aggressive cache headers and short-circuit on conditional GETs.

## What's in

- **Strong `ETag`** derived from `sha1(content . '|' . level . '|' . ext)`. Different inputs in any one of those produce a different ETag.
- **`Cache-Control: public, max-age=31536000, immutable`** by default — one year, immutable because the content is keyed by hash and never changes for a given URL+query. Apps with a different policy can override via `Configure::write('QrCode.cacheControl', '...')`.
- **`If-None-Match` short-circuit** → `304 Not Modified` with no body, repeating both `ETag` and `Cache-Control` so revalidating proxies pick up the same TTL.

## What this gives you

- Browsers cache the rendered SVG/PNG for a year on the first hit.
- A CDN in front (Cloudflare, Fastly, Varnish) serves subsequent requests entirely from the edge — the Cake app never sees them.
- Revalidating clients (e.g. mobile WebView with limited storage) get a fast 304 response without the chillerlan render running again.

## Tests

phpunit (56/56 + 1 pre-existing skip), phpstan, phpcs clean.

Three new tests in `QrCodeControllerTest`:

- `testImageEmitsCacheControlAndEtag` — basic shape + sha1 ETag form.
- `testImageReturns304WhenIfNoneMatchHits` — conditional GET path.
- `testImageEtagDiffersForDifferentContent` — different inputs ≠ ETag.
