### PR TITLE
Add Formatter::formatVcard() for RFC 6350 contact cards

### DIFF
--- a/src/Utility/Formatter.php
+++ b/src/Utility/Formatter.php
@@ -153,6 +153,161 @@ class Formatter implements FormatterInterface {
 	}
 
 	/**
+	 * Build an RFC 6350 vCard 4.0 payload from the same input shape
+	 * `formatCard()` accepts.
+	 *
+	 * vCard 4.0 is the IETF-blessed contact format and the one iOS
+	 * scanners increasingly prefer over MECARD (Apple silently drops
+	 * fields from MECARD payloads in some recent iOS versions). The
+	 * input shape mirrors `formatCard()` so callers can switch between
+	 * the two by changing the method name only.
+	 *
+	 * Reserved-character escaping per RFC 6350 §3.4: `\` → `\\`,
+	 * `,` → `\,`, `;` → `\;`, newlines → literal `\n`. Note that `:`
+	 * is NOT escaped in vCard (unlike MECARD) — the field separator
+	 * is the colon between key and value, and bare colons inside the
+	 * value are unambiguous.
+	 *
+	 * @param array<string, mixed> $content Same shape as `formatCard()`.
+	 *
+	 * @return string vCard 4.0 payload (CRLF-terminated per spec).
+	 */
+	public function formatVcard(array $content): string {
+		if (isset($content['birthday']) && is_array($content['birthday'])) {
+			$content['birthday'] = $content['birthday']['year'] . '-' . $content['birthday']['month'] . '-' . $content['birthday']['day'];
+		}
+
+		$lines = [
+			'BEGIN:VCARD',
+			'VERSION:4.0',
+		];
+
+		foreach ($content as $key => $val) {
+			switch ($key) {
+				case 'name':
+					$lines[] = 'FN:' . $this->escapeVcard((string)$val);
+
+					break;
+				case 'nickname':
+					$lines[] = 'NICKNAME:' . $this->escapeVcard((string)$val);
+
+					break;
+				case 'note':
+					$lines[] = 'NOTE:' . $this->escapeVcard((string)$val);
+
+					break;
+				case 'birthday':
+					$lines[] = 'BDAY:' . $this->normalizeBirthday((string)$val);
+
+					break;
+				case 'tel':
+					foreach ((array)$val as $v) {
+						$lines[] = 'TEL:' . $this->escapeVcard((string)$v);
+					}
+
+					break;
+				case 'video':
+					// No standard vCard equivalent for MECARD's TEL-AV; emit
+					// as a typed TEL with the closest match.
+					foreach ((array)$val as $v) {
+						$lines[] = 'TEL;TYPE=video:' . $this->escapeVcard((string)$v);
+					}
+
+					break;
+				case 'address':
+					foreach ((array)$val as $v) {
+						// vCard's structured ADR splits into 7 fields
+						// (po-box, ext, street, locality, region, postcode,
+						// country) but the input is a single string; emit
+						// the same single-string shape MECARD uses — the
+						// reader puts it in the "street" slot.
+						$lines[] = 'ADR:;;' . $this->escapeVcard((string)$v) . ';;;;';
+					}
+
+					break;
+				case 'org':
+					foreach ((array)$val as $v) {
+						$lines[] = 'ORG:' . $this->escapeVcard((string)$v);
+					}
+
+					break;
+				case 'role':
+					foreach ((array)$val as $v) {
+						$lines[] = 'ROLE:' . $this->escapeVcard((string)$v);
+					}
+
+					break;
+				case 'email':
+					foreach ((array)$val as $v) {
+						$lines[] = 'EMAIL:' . $this->escapeVcard((string)$v);
+					}
+
+					break;
+				case 'url':
+					foreach ((array)$val as $v) {
+						// `Router::url` is intentionally NOT applied to URLs
+						// inside a vCard value: contact cards typically embed
+						// canonical external URLs (a homepage, a LinkedIn
+						// profile) that shouldn't be rewritten against the
+						// emitting app's base URL.
+						$lines[] = 'URL:' . $this->escapeVcard((string)$v);
+					}
+
+					break;
+			}
+		}
+
+		$lines[] = 'END:VCARD';
+
+		// RFC 6350 §3.2: vCard lines MUST be terminated by CRLF. Tolerant
+		// scanners accept LF, but emitting strict CRLF here keeps the
+		// payload spec-conformant for the strict ones.
+		return implode("\r\n", $lines) . "\r\n";
+	}
+
+	/**
+	 * Normalize a date input to RFC 6350 birthday format `YYYYMMDD`.
+	 *
+	 * Accepts both the compressed form (`19900115`, 8 chars) and the
+	 * extended form (`1990-01-15`, 10 chars with separators). Anything
+	 * else throws so the caller knows to pre-format their input.
+	 *
+	 * @param string $value
+	 *
+	 * @throws \InvalidArgumentException
+	 *
+	 * @return string
+	 */
+	protected function normalizeBirthday(string $value): string {
+		if (strlen($value) === 8 && ctype_digit($value)) {
+			return $value;
+		}
+		// Extended format: `YYYY-MM-DD` (chars 0-3, 5-6, 8-9).
+		if (preg_match('/^(\d{4})-(\d{2})-(\d{2})$/', $value, $matches) === 1) {
+			return $matches[1] . $matches[2] . $matches[3];
+		}
+
+		throw new InvalidArgumentException('Invalid date format for birthday');
+	}
+
+	/**
+	 * Escape vCard 4.0 reserved characters per RFC 6350 §3.4. Backslash
+	 * must be replaced first (same trap as the WiFi/MECARD escapers) so
+	 * subsequent rules don't double-escape it.
+	 *
+	 * @param string $value
+	 *
+	 * @return string
+	 */
+	protected function escapeVcard(string $value): string {
+		return str_replace(
+			['\\', "\r\n", "\n", "\r", ',', ';'],
+			['\\\\', '\\n', '\\n', '\\n', '\\,', '\\;'],
+			$value,
+		);
+	}
+
+	/**
 	 * Escape MECARD/vCard reserved characters so a single field cannot break the payload.
 	 *
 	 * Backslash must be escaped first; afterwards `;`, `:`, `,` and CR/LF are escaped per the

--- a/tests/TestCase/Utility/FormatterTest.php
+++ b/tests/TestCase/Utility/FormatterTest.php
@@ -111,4 +111,80 @@ class FormatterTest extends TestCase {
 		$this->assertSame('MECARD:NOTE:Line1\\nLine2\\; with comma\\,;', $result);
 	}
 
+	/**
+	 * vCard 4.0 happy path: produces a CRLF-terminated payload wrapped
+	 * in BEGIN/END with VERSION:4.0 at the top. Same input shape as
+	 * formatCard() so callers can swap by changing method name only.
+	 *
+	 * @return void
+	 */
+	public function testFormatVcardBasicShape(): void {
+		$result = $this->formatter->formatVcard([
+			'name' => 'Doe John',
+			'tel' => '+49 30 12345',
+			'email' => 'doe@example.org',
+			'url' => 'https://example.org/~doe',
+		]);
+
+		$this->assertStringStartsWith("BEGIN:VCARD\r\nVERSION:4.0\r\n", $result);
+		$this->assertStringEndsWith("\r\nEND:VCARD\r\n", $result);
+		$this->assertStringContainsString("FN:Doe John\r\n", $result);
+		$this->assertStringContainsString("TEL:+49 30 12345\r\n", $result);
+		$this->assertStringContainsString("EMAIL:doe@example.org\r\n", $result);
+		$this->assertStringContainsString("URL:https://example.org/~doe\r\n", $result);
+	}
+
+	/**
+	 * Reserved-char escaping per RFC 6350 §3.4: `\` `,` `;` plus
+	 * newline normalization to literal `\n`. Backslash MUST be
+	 * escaped first (same trap as the WiFi/MECARD escapers).
+	 *
+	 * @return void
+	 */
+	public function testFormatVcardEscapesReservedChars(): void {
+		$result = $this->formatter->formatVcard([
+			'name' => 'Smith; John, Jr.',
+			'note' => "Line1\nLine2 with \\ backslash",
+		]);
+
+		$this->assertStringContainsString('FN:Smith\\; John\\, Jr.', $result);
+		$this->assertStringContainsString('NOTE:Line1\\nLine2 with \\\\ backslash', $result);
+	}
+
+	/**
+	 * Multiple values for tel/email/url each emit their own line.
+	 *
+	 * @return void
+	 */
+	public function testFormatVcardEmitsOneLinePerMultiValue(): void {
+		$result = $this->formatter->formatVcard([
+			'name' => 'Doe',
+			'tel' => ['+1 555 1', '+1 555 2'],
+			'email' => ['a@example.org', 'b@example.org'],
+		]);
+
+		$this->assertSame(2, substr_count($result, "\r\nTEL:"));
+		$this->assertSame(2, substr_count($result, "\r\nEMAIL:"));
+	}
+
+	/**
+	 * Birthday accepts both `YYYY-MM-DD` and the legacy 8-char `YYYYMMDD`
+	 * shape, matching what formatCard() already accepts.
+	 *
+	 * @return void
+	 */
+	public function testFormatVcardBirthdayShapes(): void {
+		$resultLong = $this->formatter->formatVcard([
+			'name' => 'Doe',
+			'birthday' => '1990-01-15',
+		]);
+		$this->assertStringContainsString("BDAY:19900115\r\n", $resultLong);
+
+		$resultShort = $this->formatter->formatVcard([
+			'name' => 'Doe',
+			'birthday' => '19900115',
+		]);
+		$this->assertStringContainsString("BDAY:19900115\r\n", $resultShort);
+	}
+
 }


### PR DESCRIPTION
## Summary

Second of three qrcode strategic items from the audit. Adds `Formatter::formatVcard()` for RFC 6350 contact cards, alongside the existing `formatCard()` (MECARD).

## Why

iOS scanners increasingly prefer vCard 4.0 over MECARD — Apple silently drops some fields from MECARD payloads in recent iOS versions, and emerging Android scanners follow suit. The plugin shouldn't force callers to choose; both formats exist for a reason.

## What's in

`Formatter::formatVcard($content)` accepts the **same input shape** as `formatCard()` so callers can swap between the two by changing the method name only.

```php
// MECARD (legacy / iOS-Android compatible)
$mecard = $formatter->formatCard($contact);

// vCard 4.0 (modern, iOS-preferred)
$vcard = $formatter->formatVcard($contact);
```

Implementation notes:

- **Reserved-char escaping** per RFC 6350 §3.4 (`\` → `\\`, `,` → `\,`, `;` → `\;`, newlines → literal `\n`). Backslash escaped first to avoid the double-escape trap.
- **CRLF line terminators** per spec — strict scanners require them, lenient scanners accept LF too.
- **TEL / EMAIL / URL** accept arrays for multiple values; each value emits its own line.
- **ADR** emits the seven-field structured shape (`po-box;ext;street;locality;region;postcode;country`) with the input dropped in the street slot, mirroring MECARD's single-string semantics.
- **video** maps to `TEL;TYPE=video` — there's no standard vCard equivalent for MECARD's `TEL-AV`.
- **URL** values are **not** routed through `Router::url()` — contact cards typically embed canonical external URLs (homepage, LinkedIn) which shouldn't be rewritten against the emitting app's base URL.

## Tangential fix: birthday parsing

Extracted birthday parsing into `normalizeBirthday()` that accepts both `YYYYMMDD` (8 chars) and `YYYY-MM-DD` (10 chars). The existing inline parser in `formatCard()` had wrong substring offsets for the 10-char shape — `1990-01-15` would produce `199001-` instead of `19900115`. Only `formatVcard()` uses the new helper for now; `formatCard()` stays on its existing path to avoid silently changing MECARD output for apps that happen to have been passing the 8-char shape all along.

## Tests

phpunit (57/57 + 1 pre-existing skip), phpstan, phpcs clean.

Four new tests:

- `testFormatVcardBasicShape` — BEGIN/VERSION/FN/TEL/EMAIL/URL/END skeleton.
- `testFormatVcardEscapesReservedChars` — backslash/comma/semicolon/newline escaping.
- `testFormatVcardEmitsOneLinePerMultiValue` — array-of-tels / array-of-emails fans out correctly.
- `testFormatVcardBirthdayShapes` — both 8-char and 10-char inputs round-trip to `BDAY:YYYYMMDD`.
