### PR TITLE
Add logo overlay support with auto ECC-H bump

### DIFF
--- a/src/View/Helper/QrCodeHelper.php
+++ b/src/View/Helper/QrCodeHelper.php
@@ -77,9 +77,29 @@ class QrCodeHelper extends Helper {
 	 * @return string
 	 */
 	public function image(string $content, array $options = []): string {
-		$options = $this->normalizeOptions($options, $content);
+		$logo = $options['logo'] ?? null;
+		$logoSize = (float)($options['logoSize'] ?? 0.2);
+		unset($options['logo'], $options['logoSize']);
+
+		$options = $this->normalizeOptions($options, $content, hasLogo: $logo !== null);
+
+		// When a logo overlays the centre of the QR code we need to render
+		// to a non-base64 stream so we can post-process the SVG to inject
+		// the logo element. Re-encode at the end so the returned data URI
+		// is still drop-in for `<img src="...">`.
+		$wantsBase64 = (bool)($options['imageBase64'] ?? true);
+		if ($logo !== null) {
+			$options['imageBase64'] = false;
+		}
 
 		$qrcode = (new QRCode(new QROptions($options)))->render($content);
+
+		if ($logo !== null) {
+			$qrcode = $this->overlayLogo($qrcode, $logo, $logoSize);
+			if ($wantsBase64 && str_contains($qrcode, '<svg ')) {
+				$qrcode = 'data:image/svg+xml;base64,' . base64_encode($qrcode);
+			}
+		}
 
 		return sprintf('<img src="%s" alt="QR Code">', h($qrcode));
 	}
@@ -127,11 +147,19 @@ class QrCodeHelper extends Helper {
 	 * @return string
 	 */
 	public function raw(string $content, array $options = []): string {
-		$options = $this->normalizeOptions($options, $content);
+		$logo = $options['logo'] ?? null;
+		$logoSize = (float)($options['logoSize'] ?? 0.2);
+		unset($options['logo'], $options['logoSize']);
 
+		$options = $this->normalizeOptions($options, $content, hasLogo: $logo !== null);
 		$options['outputBase64'] = false;
 
-		return (new QRCode(new QROptions($options)))->render($content);
+		$qrcode = (new QRCode(new QROptions($options)))->render($content);
+		if ($logo !== null) {
+			$qrcode = $this->overlayLogo($qrcode, $logo, $logoSize);
+		}
+
+		return $qrcode;
 	}
 
 	/**
@@ -162,13 +190,25 @@ class QrCodeHelper extends Helper {
 	 *     they default to level Q (~25% recovery) instead of the generic
 	 *     short-URL default L (~7%). Callers can always override by passing
 	 *     a `level` option, or set `QrCode.defaultLevel` in Configure.
+	 * @param bool $hasLogo When true, auto-bump default level to H so the
+	 *     centre overlay doesn't defeat error correction. Explicit
+	 *     caller-supplied `level` still wins.
 	 *
 	 * @return array<string, mixed>
 	 */
-	protected function normalizeOptions(array $options, ?string $content = null): array {
+	protected function normalizeOptions(array $options, ?string $content = null, bool $hasLogo = false): array {
+		$callerSetLevel = isset($options['level']);
 		$defaultLevel = $this->getConfig('defaultLevel');
 		if ($defaultLevel === null) {
 			$defaultLevel = static::defaultLevelForPayload($content);
+		}
+		// A centred logo overlays ~10-25% of the modules. Bump to H (~30%
+		// recovery) so the QR remains scannable even with the centre
+		// obscured. Honour an explicit caller-supplied `level` though —
+		// they may have a reason to insist on lower recovery for
+		// readability tests.
+		if ($hasLogo && !$callerSetLevel) {
+			$defaultLevel = 'H';
 		}
 		$options += [
 			'version' => Version::AUTO, // to avoid code length issues
@@ -203,6 +243,131 @@ class QrCodeHelper extends Helper {
 		] + $options;
 
 		return $options;
+	}
+
+	/**
+	 * Overlay a centred logo onto a rendered QR code.
+	 *
+	 * Currently supports SVG output only. PNG / Imagick overlay would need
+	 * a GD / Imagick composite, which is a bigger surface and is deferred
+	 * to a follow-up. Non-SVG renders pass through unchanged so callers
+	 * can still pass the `logo` option without breaking the response.
+	 *
+	 * @param string $rendered Output of `(new QRCode($opts))->render()`.
+	 * @param string $logo Logo source — accepts:
+	 *     - absolute filesystem path
+	 *     - path relative to WWW_ROOT
+	 *     - `data:` URI (used as-is)
+	 *     - any other URL (left as-is; rendered as an `xlink:href`)
+	 * @param float $logoSize Fraction of the QR width the logo should cover.
+	 *     Default 0.2 (20%). Clamped to [0.05, 0.35] — beyond ~35% even
+	 *     ECC-H can't recover the centre and scanners start failing.
+	 *
+	 * @return string
+	 */
+	protected function overlayLogo(string $rendered, string $logo, float $logoSize): string {
+		// SVG-only for now. The detection is shape-based rather than
+		// content-type-based because the rendered SVG might not start
+		// with the XML decl (chillerlan omits it for inline use).
+		if (!str_contains($rendered, '<svg ')) {
+			return $rendered;
+		}
+
+		$logoSize = max(0.05, min(0.35, $logoSize));
+
+		[$width, $height] = $this->detectSvgDimensions($rendered);
+		$size = min($width, $height) * $logoSize;
+		$x = ($width - $size) / 2;
+		$y = ($height - $size) / 2;
+
+		$logoUri = $this->logoToDataUri($logo);
+		// SVG 2 `href` works on all current readers; emit the SVG 1.1
+		// `xlink:href` too for older parsers that haven't caught up.
+		$imageTag = sprintf(
+			'<image x="%s" y="%s" width="%s" height="%s" '
+			. 'href="%s" xlink:href="%s" preserveAspectRatio="xMidYMid meet"/>',
+			$x,
+			$y,
+			$size,
+			$size,
+			h($logoUri),
+			h($logoUri),
+		);
+
+		// Inject before the closing `</svg>`. str_replace with `limit=1` so
+		// nested SVGs (e.g. an SVG already embedded inside the rendered
+		// QR) don't get an extra logo at the wrong level.
+		$pos = strrpos($rendered, '</svg>');
+		if ($pos === false) {
+			return $rendered;
+		}
+
+		return substr($rendered, 0, $pos) . $imageTag . substr($rendered, $pos);
+	}
+
+	/**
+	 * Extract (width, height) from an SVG string. Reads `viewBox` first
+	 * because that's the most reliable for chillerlan's output; falls back
+	 * to `width` / `height` attributes, then to a sensible default.
+	 *
+	 * @param string $svg
+     *
+	 * @return array{0: float, 1: float}
+	 */
+	protected function detectSvgDimensions(string $svg): array {
+		if (preg_match('/\bviewBox="(?:[\d.\-]+)\s+(?:[\d.\-]+)\s+([\d.]+)\s+([\d.]+)"/', $svg, $m) === 1) {
+			return [(float)$m[1], (float)$m[2]];
+		}
+		$width = 100.0;
+		$height = 100.0;
+		if (preg_match('/\swidth="([\d.]+)"/', $svg, $m) === 1) {
+			$width = (float)$m[1];
+		}
+		if (preg_match('/\sheight="([\d.]+)"/', $svg, $m) === 1) {
+			$height = (float)$m[1];
+		}
+
+		return [$width, $height];
+	}
+
+	/**
+	 * Turn a logo source into a string usable as an SVG `<image>` href.
+	 *
+	 * - `data:` URIs pass through.
+	 * - Absolute filesystem paths get base64-encoded into a `data:` URI so
+	 *   the SVG stays self-contained (important when the QR is served from
+	 *   a CDN that wouldn't fetch the logo separately).
+	 * - Relative paths are resolved against `WWW_ROOT`.
+	 * - Anything else (`http(s)://...`) is returned as-is and rendered as
+	 *   a URL reference; the browser fetches it when it paints the SVG.
+	 *
+	 * @param string $logo
+     *
+	 * @return string
+	 */
+	protected function logoToDataUri(string $logo): string {
+		if (str_starts_with($logo, 'data:') || str_starts_with($logo, 'http://') || str_starts_with($logo, 'https://')) {
+			return $logo;
+		}
+
+		$absolute = $logo;
+		if (!is_file($absolute)) {
+			$absolute = defined('WWW_ROOT') ? WWW_ROOT . ltrim($logo, '/') : $logo;
+		}
+		if (!is_file($absolute) || !is_readable($absolute)) {
+			// Fall through unchanged — the SVG will reference the URL
+			// literally. Browsers that can resolve it will; others fail
+			// gracefully (the QR is still scannable without the logo).
+			return $logo;
+		}
+
+		$contents = @file_get_contents($absolute);
+		if ($contents === false) {
+			return $logo;
+		}
+		$mime = function_exists('mime_content_type') ? (mime_content_type($absolute) ?: 'image/png') : 'image/png';
+
+		return 'data:' . $mime . ';base64,' . base64_encode($contents);
 	}
 
 	/**

--- a/tests/TestCase/View/Helper/QrCodeHelperTest.php
+++ b/tests/TestCase/View/Helper/QrCodeHelperTest.php
@@ -8,6 +8,7 @@ use Cake\View\View;
 use Imagick;
 use QrCode\Utility\FormatterInterface;
 use QrCode\View\Helper\QrCodeHelper;
+use ReflectionMethod;
 
 class QrCodeHelperTest extends TestCase {
 
@@ -202,10 +203,64 @@ class QrCodeHelperTest extends TestCase {
 	}
 
 	/**
-	 * Payload-aware ECC defaults: short URLs and plain text stay at L for
-	 * density; WiFi credentials, MECARD and vCard bumps to Q so the code
-	 * stays scannable through wear or a logo overlay.
+	 * Logo overlay happy path: the rendered output contains an `<image>`
+	 * element pointing at the supplied data URI, centred on the QR code.
 	 *
+	 * @return void
+	 */
+	public function testRawWithLogoEmbedsImageElement(): void {
+		$content = 'https://example.com';
+		$logo = 'data:image/png;base64,iVBORw0KGgo=';
+
+		$raw = $this->QrCode->raw($content, ['logo' => $logo, 'logoSize' => 0.2]);
+
+		$this->assertStringContainsString('<image', $raw);
+		$this->assertStringContainsString('preserveAspectRatio="xMidYMid meet"', $raw);
+		$this->assertStringContainsString($logo, $raw);
+	}
+
+	/**
+	 * Setting a logo auto-bumps ECC to H so the centre overlay doesn't
+	 * defeat the QR's error correction. Verified by comparing the raw
+	 * output to a normalized form with no logo at level L — the
+	 * with-logo version should have more dense module patterns
+	 * characteristic of H-level encoding.
+	 *
+	 * @return void
+	 */
+	public function testLogoAutoBumpsEccToH(): void {
+		$content = 'https://example.com';
+
+		// Use reflection to inspect what level normalizeOptions applied
+		// rather than comparing rendered byte counts (which include the
+		// injected <image> element and varying whitespace).
+		$ref = new ReflectionMethod($this->QrCode, 'normalizeOptions');
+		/** @var array<string, mixed> $withLogo */
+		$withLogo = $ref->invoke($this->QrCode, [], $content, true);
+		/** @var array<string, mixed> $withoutLogo */
+		$withoutLogo = $ref->invoke($this->QrCode, [], $content, false);
+
+		$this->assertSame('H', $withLogo['level']);
+		$this->assertNotSame('H', $withoutLogo['level']);
+	}
+
+	/**
+	 * Caller-supplied `level` wins over the auto-bump — they may have a
+	 * specific reason to insist on a lower level (e.g. readability test).
+	 *
+	 * @return void
+	 */
+	public function testLogoRespectsExplicitLevel(): void {
+		$content = 'https://example.com';
+
+		$ref = new ReflectionMethod($this->QrCode, 'normalizeOptions');
+		/** @var array<string, mixed> $withLogo */
+		$withLogo = $ref->invoke($this->QrCode, ['level' => 'M'], $content, true);
+
+		$this->assertSame('M', $withLogo['level'], 'Caller-supplied level must win over the logo auto-bump');
+	}
+
+	/**
 	 * @return void
 	 */
 	public function testDefaultLevelForPayload(): void {


### PR DESCRIPTION
## Summary

Third of three qrcode strategic items from the audit. The most-requested QR feature — center a logo (brand mark, icon) on top of the rendered code.

```php
echo $this->QrCode->image('https://example.com', [
    'logo' => '/img/logo.png',
    'logoSize' => 0.2,  // 20% of QR width
]);
```

## What's in

- **`QrCodeHelper::image()` / `::raw()`** accept two new options:
  - `logo` — file path, URL, or `data:` URI of the image to overlay
  - `logoSize` — fraction of QR width the logo should cover (default `0.2`, clamped to `[0.05, 0.35]` since beyond ~35% even ECC-H can't recover the centre)
- **Auto ECC-H bump** when a logo is set, since a centred overlay covers 10-25% of the modules and ECC-L (~7% recovery) would defeat scanning. Explicit caller-supplied `level` still wins for testing scenarios.
- **Logo source resolution:**
  - `data:` URIs pass through unchanged
  - `http(s)` URLs left as-is (browser fetches on render)
  - filesystem paths get base64-encoded into a `data:` URI so the SVG stays self-contained when served from a CDN
  - relative paths resolve against `WWW_ROOT`

## SVG implementation

Renders the QR via the existing `chillerlan/php-qrcode` pipeline, detects the SVG dimensions from `viewBox` (with `width`/`height` fallback), and injects a centred `<image>` element with `preserveAspectRatio="xMidYMid meet"` so the logo stays proportional. Emits both `href` (SVG 2) and `xlink:href` (SVG 1.1) so all current scanners and older parsers can resolve the reference.

## Scope

**SVG only for now.** PNG / Imagick overlay would need a GD / Imagick composite, which is a bigger surface and is deferred to a follow-up. Non-SVG renders pass the `logo` option through unchanged so callers don't break the response — they just don't get the overlay in those formats.

## Tests

phpunit (56/56 + 1 pre-existing skip), phpstan, phpcs clean.

Three new tests:

- `testRawWithLogoEmbedsImageElement` — `<image>` injection + `preserveAspectRatio` + the data URI round-tripped through the SVG.
- `testLogoAutoBumpsEccToH` — `normalizeOptions` returns `level: 'H'` when `hasLogo` is true and the caller didn't pin it.
- `testLogoRespectsExplicitLevel` — caller-supplied `level` wins over the auto-bump.
