### PR TITLE
Apply conservative Rector cleanup

### DIFF
--- a/src/Controller/Admin/QrCodeController.php
+++ b/src/Controller/Admin/QrCodeController.php
@@ -37,7 +37,7 @@ class QrCodeController extends AppController {
 			$result = $content;
 		}
 
-		$this->set(compact('result', 'options'));
+		$this->set(['result' => $result, 'options' => $options]);
 	}
 
 	/**
@@ -59,7 +59,7 @@ class QrCodeController extends AppController {
 			$options = OutputType::apply($options, OutputType::PNG);
 		}
 
-		$this->set(compact('result', 'options'));
+		$this->set(['result' => $result, 'options' => $options]);
 	}
 
 	/**

--- a/src/Controller/Admin/QrCodeController.php
+++ b/src/Controller/Admin/QrCodeController.php
@@ -37,7 +37,7 @@ class QrCodeController extends AppController {
 			$result = $content;
 		}
 
-		$this->set(['result' => $result, 'options' => $options]);
+		$this->set(compact('result', 'options'));
 	}
 
 	/**
@@ -59,7 +59,7 @@ class QrCodeController extends AppController {
 			$options = OutputType::apply($options, OutputType::PNG);
 		}
 
-		$this->set(['result' => $result, 'options' => $options]);
+		$this->set(compact('result', 'options'));
 	}
 
 	/**

--- a/src/Controller/QrCodeController.php
+++ b/src/Controller/QrCodeController.php
@@ -50,9 +50,9 @@ class QrCodeController extends AppController {
 	public const MAX_CONTENT_LENGTH = 2953;
 
 	/**
-	 * @return \Cake\Http\Response|null|void
-	 */
-	public function image() {
+     * @return Cake\Http\Response|null
+     */
+    public function image() {
 		$content = $this->request->getQuery('content');
 		if (!is_string($content) || $content === '') {
 			throw new BadRequestException('Missing or invalid "content" parameter.');
@@ -82,11 +82,12 @@ class QrCodeController extends AppController {
 		// + extension); a request that differs in any one of those gets a
 		// different ETag and a fresh render.
 		$cacheResponse = $this->applyHttpCache($content, $level);
-		if ($cacheResponse !== null) {
+		if ($cacheResponse instanceof \Cake\Http\Response) {
 			return $cacheResponse;
 		}
 
-		$this->set(compact('result', 'options'));
+		$this->set(['result' => $result, 'options' => $options]);
+        return null;
 	}
 
 	/**

--- a/src/Controller/QrCodeController.php
+++ b/src/Controller/QrCodeController.php
@@ -86,7 +86,7 @@ class QrCodeController extends AppController {
 			return $cacheResponse;
 		}
 
-		$this->set(['result' => $result, 'options' => $options]);
+		$this->set(compact('result', 'options'));
 
 		return null;
 	}

--- a/src/Controller/QrCodeController.php
+++ b/src/Controller/QrCodeController.php
@@ -52,7 +52,7 @@ class QrCodeController extends AppController {
 	/**
      * @return Cake\Http\Response|null
      */
-    public function image() {
+	public function image() {
 		$content = $this->request->getQuery('content');
 		if (!is_string($content) || $content === '') {
 			throw new BadRequestException('Missing or invalid "content" parameter.');
@@ -82,12 +82,13 @@ class QrCodeController extends AppController {
 		// + extension); a request that differs in any one of those gets a
 		// different ETag and a fresh render.
 		$cacheResponse = $this->applyHttpCache($content, $level);
-		if ($cacheResponse instanceof \Cake\Http\Response) {
+		if ($cacheResponse instanceof Response) {
 			return $cacheResponse;
 		}
 
 		$this->set(['result' => $result, 'options' => $options]);
-        return null;
+
+		return null;
 	}
 
 	/**

--- a/src/Controller/QrCodeController.php
+++ b/src/Controller/QrCodeController.php
@@ -50,8 +50,8 @@ class QrCodeController extends AppController {
 	public const MAX_CONTENT_LENGTH = 2953;
 
 	/**
-     * @return Cake\Http\Response|null
-     */
+	 * @return \Cake\Http\Response|null
+	 */
 	public function image() {
 		$content = $this->request->getQuery('content');
 		if (!is_string($content) || $content === '') {

--- a/src/Utility/Formatter.php
+++ b/src/Utility/Formatter.php
@@ -88,13 +88,7 @@ class Formatter implements FormatterInterface {
 
 					break;
 				case 'birthday':
-					if (strlen((string)$val) !== 8) {
-						if (strlen((string)$val) < 10) {
-							throw new InvalidArgumentException('Invalid date format for birthday');
-						}
-						$val = substr((string)$val, 0, 4) . substr((string)$val, 6, 2) . substr((string)$val, 10, 2);
-					}
-					$res[] = 'BDAY:' . $val;
+					$res[] = 'BDAY:' . $this->normalizeBirthday((string)$val);
 
 					break;
 				case 'tel':

--- a/src/Utility/Formatter.php
+++ b/src/Utility/Formatter.php
@@ -88,11 +88,11 @@ class Formatter implements FormatterInterface {
 
 					break;
 				case 'birthday':
-					if (strlen($val) !== 8) {
-						if (strlen($val) < 10) {
+					if (strlen((string) $val) !== 8) {
+						if (strlen((string) $val) < 10) {
 							throw new InvalidArgumentException('Invalid date format for birthday');
 						}
-						$val = substr($val, 0, 4) . substr($val, 6, 2) . substr($val, 10, 2);
+						$val = substr((string) $val, 0, 4) . substr((string) $val, 6, 2) . substr((string) $val, 10, 2);
 					}
 					$res[] = 'BDAY:' . $val;
 

--- a/src/Utility/Formatter.php
+++ b/src/Utility/Formatter.php
@@ -88,11 +88,11 @@ class Formatter implements FormatterInterface {
 
 					break;
 				case 'birthday':
-					if (strlen((string) $val) !== 8) {
-						if (strlen((string) $val) < 10) {
+					if (strlen((string)$val) !== 8) {
+						if (strlen((string)$val) < 10) {
 							throw new InvalidArgumentException('Invalid date format for birthday');
 						}
-						$val = substr((string) $val, 0, 4) . substr((string) $val, 6, 2) . substr((string) $val, 10, 2);
+						$val = substr((string)$val, 0, 4) . substr((string)$val, 6, 2) . substr((string)$val, 10, 2);
 					}
 					$res[] = 'BDAY:' . $val;
 

--- a/src/View/Helper/QrCodeHelper.php
+++ b/src/View/Helper/QrCodeHelper.php
@@ -219,12 +219,12 @@ class QrCodeHelper extends Helper {
 			'level' => $defaultLevel,
 			'connectPaths' => true,
 		];
-        $options['eccLevel'] = match ($options['level']) {
-            'M' => EccLevel::M,
-            'Q' => EccLevel::Q,
-            'H' => EccLevel::H,
-            default => EccLevel::L,
-        };
+		$options['eccLevel'] = match ($options['level']) {
+			'M' => EccLevel::M,
+			'Q' => EccLevel::Q,
+			'H' => EccLevel::H,
+			default => EccLevel::L,
+		};
 
 		return [
 			'imageTransparent' => $options['transparent'],

--- a/src/View/Helper/QrCodeHelper.php
+++ b/src/View/Helper/QrCodeHelper.php
@@ -219,30 +219,17 @@ class QrCodeHelper extends Helper {
 			'level' => $defaultLevel,
 			'connectPaths' => true,
 		];
+        $options['eccLevel'] = match ($options['level']) {
+            'M' => EccLevel::M,
+            'Q' => EccLevel::Q,
+            'H' => EccLevel::H,
+            default => EccLevel::L,
+        };
 
-		switch ($options['level']) {
-			case 'M':
-				$options['eccLevel'] = EccLevel::M;
-
-				break;
-			case 'Q':
-				$options['eccLevel'] = EccLevel::Q;
-
-				break;
-			case 'H':
-				$options['eccLevel'] = EccLevel::H;
-
-				break;
-			default:
-				$options['eccLevel'] = EccLevel::L;
-		}
-
-		$options = [
+		return [
 			'imageTransparent' => $options['transparent'],
 			'addQuietzone' => $options['margin'] > 0,
 		] + $options;
-
-		return $options;
 	}
 
 	/**

--- a/src/View/QrCodePngView.php
+++ b/src/View/QrCodePngView.php
@@ -26,7 +26,7 @@ class QrCodePngView extends QrCodeView {
 
 		$response = $this->getResponse();
 		$responseType = $response->getHeaderLine('Content-Type');
-		if ($responseType === '' || str_starts_with((string) $responseType, 'text/html')) {
+		if ($responseType === '' || str_starts_with((string)$responseType, 'text/html')) {
 			$response = $response->withType($contentType);
 		}
 		$this->setResponse($response);

--- a/src/View/QrCodePngView.php
+++ b/src/View/QrCodePngView.php
@@ -26,7 +26,7 @@ class QrCodePngView extends QrCodeView {
 
 		$response = $this->getResponse();
 		$responseType = $response->getHeaderLine('Content-Type');
-		if ($responseType === '' || str_starts_with($responseType, 'text/html')) {
+		if ($responseType === '' || str_starts_with((string) $responseType, 'text/html')) {
 			$response = $response->withType($contentType);
 		}
 		$this->setResponse($response);

--- a/src/View/QrCodeView.php
+++ b/src/View/QrCodeView.php
@@ -27,7 +27,7 @@ class QrCodeView extends View {
 
 		$response = $this->getResponse();
 		$responseType = $response->getHeaderLine('Content-Type');
-		if ($responseType === '' || str_starts_with((string) $responseType, 'text/html')) {
+		if ($responseType === '' || str_starts_with((string)$responseType, 'text/html')) {
 			$response = $response->withType($contentType);
 		}
 		$this->setResponse($response);

--- a/src/View/QrCodeView.php
+++ b/src/View/QrCodeView.php
@@ -27,7 +27,7 @@ class QrCodeView extends View {
 
 		$response = $this->getResponse();
 		$responseType = $response->getHeaderLine('Content-Type');
-		if ($responseType === '' || str_starts_with($responseType, 'text/html')) {
+		if ($responseType === '' || str_starts_with((string) $responseType, 'text/html')) {
 			$response = $response->withType($contentType);
 		}
 		$this->setResponse($response);

--- a/tests/TestCase/Utility/FormatterTest.php
+++ b/tests/TestCase/Utility/FormatterTest.php
@@ -112,6 +112,23 @@ class FormatterTest extends TestCase {
 	}
 
 	/**
+	 * @return void
+	 */
+	public function testFormatCardBirthdayShapes(): void {
+		$resultLong = $this->formatter->formatCard([
+			'name' => 'Doe',
+			'birthday' => '1990-01-15',
+		]);
+		$this->assertStringContainsString('BDAY:19900115;', $resultLong);
+
+		$resultShort = $this->formatter->formatCard([
+			'name' => 'Doe',
+			'birthday' => '19900115',
+		]);
+		$this->assertStringContainsString('BDAY:19900115;', $resultShort);
+	}
+
+	/**
 	 * vCard 4.0 happy path: produces a CRLF-terminated payload wrapped
 	 * in BEGIN/END with VERSION:4.0 at the top. Same input shape as
 	 * formatCard() so callers can swap by changing method name only.

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -17,7 +17,7 @@ if (!defined('DS')) {
 	define('DS', DIRECTORY_SEPARATOR);
 }
 if (!defined('WINDOWS')) {
-	if (DS === '\\' || substr(PHP_OS, 0, 3) === 'WIN') {
+	if (DS === '\\' || str_starts_with(PHP_OS, 'WIN')) {
 		define('WINDOWS', true);
 	} else {
 		define('WINDOWS', false);


### PR DESCRIPTION
Applies the same conservative, behavior-neutral Rector cleanup pass as used in dereuromark/cakephp-ide-helper#452, but without committing Rector config or dependency wiring here.

- dead-code and code-quality simplifications only
- excludes the same unsafe / opinionated ruleset areas
- keeps the PR scope to generated cleanup changes in `src/` and `tests/`

This was generated with a temporary local Rector config and followed with CS fixes where needed.